### PR TITLE
Build docs in CI.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,18 @@
-# Run generate-doc script.
+# Run generate-docs script.
 
 # TODO: push on master shimming-toolbox
-#trigger:
+trigger:
+- master
 
 # use the self-hosted runner at tristano.neuro.polymtl.ca
 # this has Matlab installed and a license to use it.
 pool: 'Default'
 
 steps:
+
 - script: |
-    # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
-    # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
-    matlab -nodisplay -nosplash -r "disp('Hello from Matlab'); quit"
-  displayName: 'Generate-doc'
+    ./generate-docs.sh
+  displayName: 'Generate and publish website'
+  env:
+    GH_PAGES_TOKEN: $(GH_PAGES_TOKEN)
+    CUSTOM_DOMAIN: www.shimming-toolbox.org

--- a/docs/2_getting_started/3_help.md
+++ b/docs/2_getting_started/3_help.md
@@ -1,4 +1,4 @@
 # Help
 
-If you need help using the `shimming-toolbox`, please contact the developer
+If you need aid using the `shimming-toolbox`, please contact the developer
 team via a [Github issue](https://github.com/shimming-toolbox/shimming-toolbox/issues).

--- a/generate-docs.sh
+++ b/generate-docs.sh
@@ -15,8 +15,19 @@ set -e
 # with hints from https://github.com/DavidS/jekyll-deploy/blob/master/entrypoint.rb and https://docs.travis-ci.com/user/deployment/pages/
 # maybe it should be its own script?
 
-export PATH="~/.local/bin":"$PATH"
-pip install --user mkdocs
+# install mkdocs
+# TODO: move this to a dependencies phase instead?
+#export PATH="~/.local/bin":"$PATH"
+#pip install --user mkdocs
+
+# we need to do this in an explicit venv since our build agent
+# isn't fancy enough to spawn fresh containers/VMs for us
+pip install --user virtualenv
+VENV=$(mktemp -d)
+trap 'rm -rf $VENV' EXIT  # cleanup after ourselves
+python -m virtualenv "$VENV"
+. "$VENV"/bin/activate
+pip install --no-cache-dir --ignore-installed mkdocs
 
 if [ -n "${GH_PAGES_TOKEN}" ]; then
     # XXX this is destructive to the repo, but we're assuming this is being run in CI so no matter?

--- a/generate-docs.sh
+++ b/generate-docs.sh
@@ -29,14 +29,17 @@ python -m virtualenv "$VENV"
 . "$VENV"/bin/activate
 pip install --no-cache-dir --ignore-installed mkdocs
 
+
 if [ -n "${GH_PAGES_TOKEN}" ]; then
     # XXX this is destructive to the repo, but we're assuming this is being run in CI so no matter?
 
     #git config http."https://github.com/".extraheader "Authorization: token $GH_PAGES_TOKEN" # authenticate over HTTPS with the given token
     # ^ this doesn't work. github will accept 'token ...' for API calls, but not for git+https://
     # so instead we have to generate an HTTP basic auth:
-    auth="$(echo -n "x-access-token:$GH_PAGES_TOKEN" | base64 | tr -d '\r' | tr -d '\n')"
-    git config http."https://github.com/".extraheader "Authorization: basic "$auth"" # authenticate over HTTPS with the given token
+    #auth="$(echo -n "x-access-token:$GH_PAGES_TOKEN" | base64 | tr -d '\r' | tr -d '\n')"
+    #git config http."https://github.com/".extraheader "Authorization: basic "$auth"" # authenticate over HTTPS with the given token
+
+    git remote set-url --push origin $(git remote get-url origin | sed 's!https://!https://x-access-token:'"$GH_PAGES_TOKEN"'@!')
 
     git config url."https://github".insteadOf "git@github.com:"  # force HTTPS, not SSH
 
@@ -49,5 +52,6 @@ fi
 if [ -n "${CUSTOM_DOMAIN}" ]; then
     echo "${CUSTOM_DOMAIN}" > "docs/CNAME"
 fi
+
 
 mkdocs gh-deploy --config-file "./mkdocs.yml" --force

--- a/generate-docs.sh
+++ b/generate-docs.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -e
+
+# Build API documentation, Matlab (.m) -> Markdown (.md)
+#   Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
+#   https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
+# TODO: broken.
+#  1. writes to temp/shimming-toolbox/docs instead of docs/
+#  2. incompatible with Matlab R2019a which is what's on our CI machine.
+#matlab -nodisplay -nosplash -r "run('genDoc/generate_doc.m');exit"
+
+# run mkdocs
+# ported from https://github.com/mhausenblas/mkdocs-deploy-gh-pages/blob/master/action.sh
+# with hints from https://github.com/DavidS/jekyll-deploy/blob/master/entrypoint.rb and https://docs.travis-ci.com/user/deployment/pages/
+# maybe it should be its own script?
+
+export PATH="~/.local/bin":"$PATH"
+pip install --user mkdocs
+
+if [ -n "${GH_PAGES_TOKEN}" ]; then
+    # XXX this is destructive to the repo, but we're assuming this is being run in CI so no matter?
+
+    #git config http."https://github.com/".extraheader "Authorization: token $GH_PAGES_TOKEN" # authenticate over HTTPS with the given token
+    # ^ this doesn't work. github will accept 'token ...' for API calls, but not for git+https://
+    # so instead we have to generate an HTTP basic auth:
+    auth="$(echo -n "x-access-token:$GH_PAGES_TOKEN" | base64 | tr -d '\r' | tr -d '\n')"
+    git config http."https://github.com/".extraheader "Authorization: basic "$auth"" # authenticate over HTTPS with the given token
+
+    git config url."https://github".insteadOf "git@github.com:"  # force HTTPS, not SSH
+
+    # if you can parse out the remote URL, you could instead try:
+    # remote_repo="https://x-access-token:${GH_PAGES_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" # 
+    # git remote rm origin
+    # git remote add origin "${remote_repo}"
+fi
+
+if [ -n "${CUSTOM_DOMAIN}" ]; then
+    echo "${CUSTOM_DOMAIN}" > "docs/CNAME"
+fi
+
+mkdocs gh-deploy --config-file "./mkdocs.yml" --force


### PR DESCRIPTION
Add GH_PAGES_TOKEN in prep to port publishing to Azure, run `helpDocMd` for the API reference, and then `mkdocs` to build and publish the website.

Fixes #14 (though maybe not /well/). Also, the bulk of the work is thanks to @rtopfer's https://github.com/shimming-toolbox/helpDocMd which @po09i already worked on importing so I'm not at all taking credit for this.